### PR TITLE
Remove duplicates

### DIFF
--- a/gcp/iam/iam_service.go
+++ b/gcp/iam/iam_service.go
@@ -101,7 +101,7 @@ func (s *iamService) GetUsers(ctx context.Context, configMap *config.ConfigMap) 
 			}
 
 			for _, item := range items {
-				if !ids.Contains(item.ExternalId) || t == GSuite {
+				if !ids.Contains(item.ExternalId) {
 					ids.Add(item.ExternalId)
 					users = append(users, item)
 				}
@@ -132,7 +132,7 @@ func (s *iamService) GetGroups(ctx context.Context, configMap *config.ConfigMap)
 			}
 
 			for _, item := range items {
-				if !ids.Contains(item.ExternalId) || t == GSuite {
+				if !ids.Contains(item.ExternalId) {
 					ids.Add(item.ExternalId)
 					groups = append(groups, item)
 				}
@@ -148,6 +148,8 @@ func (s *iamService) GetServiceAccounts(ctx context.Context, configMap *config.C
 
 	typeToIdsMap, err := s.getIdsByRepoType(ctx, configMap)
 
+	ids := set.NewSet[string]()
+
 	if err != nil {
 		return serviceAccounts, err
 	}
@@ -160,7 +162,12 @@ func (s *iamService) GetServiceAccounts(ctx context.Context, configMap *config.C
 				return nil, err2
 			}
 
-			serviceAccounts = append(serviceAccounts, u...)
+			for _, item := range u {
+				if !ids.Contains(item.ExternalId) {
+					ids.Add(item.ExternalId)
+					serviceAccounts = append(serviceAccounts, item)
+				}
+			}
 		}
 	}
 

--- a/gcp/identity_store.go
+++ b/gcp/identity_store.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"context"
 	"fmt"
+
 	"github.com/raito-io/golang-set/set"
 
 	"github.com/raito-io/cli-plugin-gcp/gcp/common"

--- a/gcp/identity_store.go
+++ b/gcp/identity_store.go
@@ -2,6 +2,8 @@ package gcp
 
 import (
 	"context"
+	"fmt"
+	"github.com/raito-io/golang-set/set"
 
 	"github.com/raito-io/cli-plugin-gcp/gcp/common"
 	"github.com/raito-io/cli-plugin-gcp/gcp/iam"
@@ -40,7 +42,7 @@ func (s *IdentityStoreSyncer) WithIAMServiceProvider(provider func(configMap *co
 
 func (s *IdentityStoreSyncer) SyncIdentityStore(ctx context.Context, identityHandler wrappers.IdentityStoreIdentityHandler, configMap *config.ConfigMap) error {
 	// get groups and make a membership map key: ID of user/group, value array of Group IDs it is member of
-	groupMembership := make(map[string][]string)
+	groupMembership := make(map[string]set.Set[string])
 
 	groups, err := s.iamServiceProvider(configMap).GetGroups(ctx, configMap)
 
@@ -50,21 +52,32 @@ func (s *IdentityStoreSyncer) SyncIdentityStore(ctx context.Context, identityHan
 
 	groupList := make([]*is.Group, 0)
 
+	handledGroups := set.NewSet[string]()
+
 	for _, g := range groups {
+		// Make sure to always handle the members for all the found groups.
 		for _, m := range g.Members {
 			if _, f := groupMembership[m]; !f {
-				groupMembership[m] = []string{g.ExternalId}
+				groupMembership[m] = set.NewSet[string](g.ExternalId)
 			} else {
-				groupMembership[m] = append(groupMembership[m], g.ExternalId)
+				groupMembership[m].Add(g.ExternalId)
 			}
 		}
+
+		// No need to handle the group multiple times.
+		if handledGroups.Contains(g.ExternalId) {
+			common.Logger.Info(fmt.Sprintf("skipping group with external id %s as it was already encountered before", g.ExternalId))
+			continue
+		}
+
+		handledGroups.Add(g.ExternalId)
 
 		groupList = append(groupList, &is.Group{ExternalId: g.ExternalId, Name: g.Email, DisplayName: g.Email})
 	}
 
 	for i, g := range groupList {
 		if _, f := groupMembership[g.ExternalId]; f {
-			groupList[i].ParentGroupExternalIds = groupMembership[g.ExternalId]
+			groupList[i].ParentGroupExternalIds = groupMembership[g.ExternalId].Slice()
 		}
 	}
 
@@ -83,9 +96,18 @@ func (s *IdentityStoreSyncer) SyncIdentityStore(ctx context.Context, identityHan
 		return err
 	}
 
+	handledUsers := set.NewSet[string]()
+
 	for _, u := range users {
+		if handledUsers.Contains(u.ExternalId) {
+			common.Logger.Info(fmt.Sprintf("skipping user with external id %s as it was already encountered before", u.ExternalId))
+			continue
+		}
+
+		handledUsers.Add(u.ExternalId)
+
 		if _, f := groupMembership[u.ExternalId]; f {
-			err2 := identityHandler.AddUsers(&is.User{ExternalId: u.ExternalId, UserName: u.Email, Email: u.Email, Name: u.Name, GroupExternalIds: groupMembership[u.ExternalId]})
+			err2 := identityHandler.AddUsers(&is.User{ExternalId: u.ExternalId, UserName: u.Email, Email: u.Email, Name: u.Name, GroupExternalIds: groupMembership[u.ExternalId].Slice()})
 
 			if err2 != nil {
 				return err2

--- a/gcp/identity_store_test.go
+++ b/gcp/identity_store_test.go
@@ -27,6 +27,12 @@ func TestIdentityStoreSyncer_SyncIdentityStore(t *testing.T) {
 		{
 			ExternalId: "g2",
 			Email:      "g2@example.com",
+			Members:    []string{},
+		},
+		// Test out a duplicate group (now with the members)
+		{
+			ExternalId: "g2",
+			Email:      "g2@example.com",
 			Members:    []string{"user2"},
 		},
 	}, nil).Once()
@@ -40,6 +46,12 @@ func TestIdentityStoreSyncer_SyncIdentityStore(t *testing.T) {
 			ExternalId: "user2",
 			Name:       "user2",
 			Email:      "user2@example.com",
+		},
+		// Testing out a duplicate user
+		{
+			ExternalId: "user1",
+			Name:       "user1",
+			Email:      "user1@example.com",
 		},
 	}, nil).Once()
 	iamServiceMock.EXPECT().GetServiceAccounts(mock.Anything, mock.Anything).Return([]iam.UserEntity{


### PR DESCRIPTION
The issue is that we check multiple IAM repositories. This is needed because on the folder or project level, there may be assignments to groups/users that are not in GCP (you can assign things to email addresses outside of the org, for example).

Therefor, we need to filter out the duplicates afterwards. We do still need to take care of the members correctly though.
